### PR TITLE
商品削除機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :create, :edit, :update]
-  before_action :set_item, only: [:show, :edit, :update]
-  before_action :move_to_index, except: [:index, :new, :create, :show]
+  before_action :authenticate_user!, only: [:new, :create, :destory, :edit, :update]
+  before_action :set_item, only: [:show, :destroy, :edit, :update]
+  before_action :move_to_index, except: [:index, :new, :create, :show, :destroy]
 
   def index
     @items = Item.all.order('created_at DESC')
@@ -21,6 +21,11 @@ class ItemsController < ApplicationController
   end
 
   def show
+  end
+
+  def destroy
+    @item.destroy
+    redirect_to root_path
   end
 
   def edit
@@ -46,6 +51,6 @@ class ItemsController < ApplicationController
   end
 
   def move_to_index
-    return redirect_to root_path if current_user.id != @item.user.id
+    redirect_to root_path if current_user.id != @item.user.id
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :create, :destory, :edit, :update]
+  before_action :authenticate_user!, only: [:new, :create, :destroy, :edit, :update]
   before_action :set_item, only: [:show, :destroy, :edit, :update]
   before_action :move_to_index, except: [:index, :new, :create, :show, :destroy]
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -24,7 +24,7 @@
     <% if user_signed_in? && @item.user_id == current_user.id && !Order.exists?(item_id: @item.id) %>
       <%= link_to "商品の編集", edit_item_path, method: :get, class: "item-red-btn" %>
       <p class="or-text">or</p>
-      <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
+      <%= link_to "削除", item_path, data: {turbo_method: :delete}, class:"item-destroy" %>
     <% elsif user_signed_in? && @item.user_id != current_user.id && !Order.exists?(item_id: @item.id) %>
       <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
-  resources :items, only: [:index, :new, :create, :show, :edit, :update]
+  resources :items
 end


### PR DESCRIPTION
#What

- ログイン状態の場合にのみ、自身が出品した商品情報を削除できる
※実装済の詳細ページにおける「削除」ボタンの表示・非表示に加え、コントローラー側でも条件を設定しました
- コントローラー内の重複するコードはbefore_actionに纏めました
- ルーティング７つのアクションは纏めました

#Why

- 商品削除機能の実装のため

ーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーー
お疲れ様です。
商品削除機能を実装いたしました。コードレビューをお願いいたします。

下記は商品削除機能に関するGYAZO GIFのurlです。

- ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
[https://gyazo.com/f6a045473466bbd8e166be250f0c9a76](url)

以上、宜しくお願いいたします。